### PR TITLE
Small changes to make running example_data_sampler.py easier

### DIFF
--- a/readers/example_data_sampler.py
+++ b/readers/example_data_sampler.py
@@ -1,7 +1,8 @@
-import pyanitools as pya
+import lib.pyanitools as pya
+import os
 
-# Set the HDF5 file containing the data
-hdf5file = '../ani_gdb_s01.h5'
+# Set the HDF5 file containing the testdata
+hdf5file = os.path.join(os.path.dirname(__file__), '../benchmark/ani1_gdb10_ts.h5')
 
 # Construct the data loader class
 adl = pya.anidataloader(hdf5file)

--- a/readers/example_data_sampler.py
+++ b/readers/example_data_sampler.py
@@ -1,7 +1,8 @@
-import pyanitools as pya
+import lib.pyanitools as pya
+import os
 
-# Set the HDF5 file containing the data
-hdf5file = '../ani_gdb_s01.h5'
+# Set the HDF5 file containing the testdata
+hdf5file = os.path.join(os.path.dirname(__file__), './../benchmark/ani1_gdb10_ts.h5')
 
 # Construct the data loader class
 adl = pya.anidataloader(hdf5file)

--- a/readers/lib/pyanitools.py
+++ b/readers/lib/pyanitools.py
@@ -56,7 +56,7 @@ class anidataloader(object):
                 data = {'path':path}
                 for k in keys:
                     if not isinstance(item[k], h5py.Group):
-                        dataset = np.array(item[k].value)
+                        dataset = np.array(item[k])
 
                         if type(dataset) is np.ndarray:
                             if dataset.size != 0:


### PR DESCRIPTION
Changes:

1. Use a relative path to import `pyanitools`
2. Use a path relative to `example_data_sampler.py` script to load test data
3. Change example script test dataset name to match the h5 file in benchmark/ directory
4. Remove the usage of a deprecated `.value` attribute in h5py

Verification:

Used this Colab to verify loading benchmark test data was correct: https://colab.research.google.com/drive/1vd9Z0i45sKOq-y5snegP1M5dyPjokjKn#scrollTo=BXlStLJUCKdT